### PR TITLE
fix: update size prop to fontSize in Heading

### DIFF
--- a/src/Heading/Heading.stories.mdx
+++ b/src/Heading/Heading.stories.mdx
@@ -30,7 +30,7 @@ import { Heading } from 'minerva-ui'
 
 ### Small h4 Heading
 ```jsx
-<Heading as="h4" size="sm">
+<Heading as="h4" fontSize="sm">
   Heading
 </Heading>
 ```


### PR DESCRIPTION
Updated the "size" prop to "fontSize" in `/Heading.stories.mdx`. 

The size prop would work to change the height/width of the Component, but the options are different.
![image](https://user-images.githubusercontent.com/35667059/77930609-b6fa9300-7270-11ea-9fa9-87f4303c09f5.png)
