### PR TITLE
fix: refactor icons to not be included in default theme

### DIFF
--- a/docs/docs/components/Icon.mdx
+++ b/docs/docs/components/Icon.mdx
@@ -4,8 +4,6 @@ title: 'Icon'
 
 The Icon component renders an SVG icon, and can be extended through the `icons` property in your theme.
 
-The default theme includes [Feather Icons](https://feathericons.com/).
-
 ```js
 import { Icon } from 'minerva-ui';
 ```
@@ -14,13 +12,26 @@ import { Icon } from 'minerva-ui';
 <Icon name="activity" />
 ```
 
+## Usage
+
+To use default icons from [Feather Icons](https://feathericons.com/), you have to manually import the default icons and add them to the theme.
+
+```jsx
+import { defaultIcons } from 'minerva-ui';
+const customTheme = {
+  icons: defaultIcons,
+};
+
+return <ThemeProvider theme={customTheme}>{/* etc */}</ThemeProvider>;
+```
+
 ## Color
 
 ```jsx live
-<>
+<ThemeProvider>
   <Icon name="plus" color="blue.600" />
   <Icon name="activity" color="purple.500" />
-</>
+</ThemeProvider>
 ```
 
 ## Size live

--- a/docs/docusaurus-theme-live-codeblock/theme/CodeBlock/index.js
+++ b/docs/docusaurus-theme-live-codeblock/theme/CodeBlock/index.js
@@ -99,7 +99,12 @@ export default ({
 
   if (language === 'jsx' && !highlightOnly) {
     return (
-      <Minerva.ThemeProvider>
+      <Minerva.ThemeProvider
+        theme={{
+          ...Minerva.defaultTheme,
+          icons: Minerva.defaultIcons,
+        }}
+      >
         <Playground
           key={mounted}
           scope={{ ...React, ...Minerva }}

--- a/src/Icon/index.tsx
+++ b/src/Icon/index.tsx
@@ -27,8 +27,12 @@ export const Icon = forwardRef(function Icon(
   const theme = useTheme();
 
   if (!theme || !theme.icons || !theme.icons[name]) {
-    console.warn(`Could not find icon in theme with name of ${name}`);
-    return null;
+    if (process.env.NODE_ENV === 'development') {
+      throw new Error(`Could not find icon in theme with name of ${name}`);
+    } else {
+      console.warn(`Could not find icon in theme with name of ${name}`);
+      return null;
+    }
   }
 
   const IconComponent = theme.icons[name] || null;

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -15,7 +15,7 @@ import {
 } from 'styled-system';
 import { Block, MinervaProps } from '../layout';
 import Input from '../Input';
-import Icon from '../Icon';
+// import Icon from '../Icon';
 
 const StyledSelect = styled(Input)(
   (props): any => ({
@@ -99,7 +99,25 @@ const IconContainer = styled('div')(
 
 const SelectIcon = () => (
   <IconContainer>
-    <Icon name="chevron-down" size="20px" />
+    <svg
+      style={{
+        width: 20,
+        height: 20,
+      }}
+      fill="none"
+      height="24"
+      role="presentation"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>Down Arrow</title>
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
   </IconContainer>
 );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,12 @@ export {
   ReachGlobalStyles,
   CSSReset,
 } from './GlobalStyles';
-export { default as defaultTheme, useTheme, useComponentStyles } from './theme';
+export {
+  default as defaultTheme,
+  useTheme,
+  useComponentStyles,
+  defaultIcons,
+} from './theme';
 export { default as baseTheme } from './theme';
 export { default as styled } from 'styled-components';
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -15,6 +15,14 @@ function toKebabCase(string) {
     .toLowerCase();
 }
 
+export const defaultIcons: { [key: string]: any } = Object.keys(Icon).reduce(
+  (result, iconName) => {
+    result[toKebabCase(iconName)] = Icon[iconName];
+    return result;
+  },
+  {}
+);
+
 export interface ThemeComponent extends React.CSSProperties, PseudoBoxProps {}
 
 export interface MinervaTheme extends Theme {
@@ -120,10 +128,13 @@ const defaultTheme: MinervaTheme = {
   Skeleton: {},
   Switch: {},
   defaultBorderColor: '#d2d6dc',
-  icons: Object.keys(Icon).reduce((result, iconName) => {
-    result[toKebabCase(iconName)] = Icon[iconName];
-    return result;
-  }, {}),
+  icons: {
+    x: defaultIcons.x,
+    check: defaultIcons.check,
+    'chevron-down': defaultIcons['chevron-down'],
+    'alert-circle': defaultIcons['alert-circle'],
+    circle: defaultIcons['circle'],
+  },
   colors: {
     // custom colors
     // primary: '#6979F8',

--- a/test/__snapshots__/select.test.tsx.snap
+++ b/test/__snapshots__/select.test.tsx.snap
@@ -1,17 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Select /> should change style if disabled 1`] = `
-.c3 {
-  box-sizing: border-box;
-  min-width: 0;
-  color: #374151;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
-  width: 20px;
-  height: 20px;
-  stroke: currentColor;
-  color: #000;
-}
-
 .c0 {
   box-sizing: border-box;
   min-width: 0;
@@ -111,7 +100,7 @@ exports[`<Select /> should change style if disabled 1`] = `
     Name
   </label>
   <div
-    class="c0"
+    class="sc-AxjAm c0"
   >
     <select
       class="c1"
@@ -133,7 +122,6 @@ exports[`<Select /> should change style if disabled 1`] = `
       class="c2"
     >
       <svg
-        class="c3"
         fill="none"
         height="24"
         role="presentation"
@@ -141,11 +129,14 @@ exports[`<Select /> should change style if disabled 1`] = `
         stroke-linecap="round"
         stroke-linejoin="round"
         stroke-width="2"
-        title="chevron down"
+        style="width: 20px; height: 20px;"
         viewBox="0 0 24 24"
         width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
+        <title>
+          Down Arrow
+        </title>
         <polyline
           points="6 9 12 15 18 9"
         />
@@ -156,17 +147,6 @@ exports[`<Select /> should change style if disabled 1`] = `
 `;
 
 exports[`<Select /> should render 1`] = `
-.c3 {
-  box-sizing: border-box;
-  min-width: 0;
-  color: #374151;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
-  width: 20px;
-  height: 20px;
-  stroke: currentColor;
-  color: #000;
-}
-
 .c0 {
   box-sizing: border-box;
   min-width: 0;
@@ -266,7 +246,7 @@ exports[`<Select /> should render 1`] = `
     Name
   </label>
   <div
-    class="c0"
+    class="sc-AxjAm c0"
   >
     <select
       class="c1"
@@ -287,7 +267,6 @@ exports[`<Select /> should render 1`] = `
       class="c2"
     >
       <svg
-        class="c3"
         fill="none"
         height="24"
         role="presentation"
@@ -295,11 +274,14 @@ exports[`<Select /> should render 1`] = `
         stroke-linecap="round"
         stroke-linejoin="round"
         stroke-width="2"
-        title="chevron down"
+        style="width: 20px; height: 20px;"
         viewBox="0 0 24 24"
         width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
+        <title>
+          Down Arrow
+        </title>
         <polyline
           points="6 9 12 15 18 9"
         />

--- a/test/checkbox.test.tsx
+++ b/test/checkbox.test.tsx
@@ -19,7 +19,12 @@ import { Checkbox, ThemeProvider } from '../src';
 describe('Checkbox', () => {
   it('renders without crashing', () => {
     const div = document.createElement('div');
-    ReactDOM.render(<Checkbox />, div);
+    ReactDOM.render(
+      <ThemeProvider>
+        <Checkbox />
+      </ThemeProvider>,
+      div
+    );
     ReactDOM.unmountComponentAtNode(div);
   });
 

--- a/test/system.test.tsx
+++ b/test/system.test.tsx
@@ -28,6 +28,7 @@ import {
   Tabs,
   // Skeleton,
   defaultTheme,
+  defaultIcons,
 } from '../src';
 import { ThemeProvider } from '../src';
 expect.extend(toHaveNoViolations);
@@ -64,6 +65,11 @@ const basicComponents = {
 
 const allComponents = { ...basicComponents };
 
+const themeWithIcons = {
+  ...defaultTheme,
+  icons: defaultIcons,
+};
+
 // one giant component that renders all library components
 const KitchenSink = () => {
   return (
@@ -93,7 +99,7 @@ const KitchenSink = () => {
 describe('Accessibility', () => {
   it('all components should pass basic accessibility checks', async () => {
     const { container } = render(
-      <ThemeProvider>
+      <ThemeProvider theme={themeWithIcons}>
         <KitchenSink />
       </ThemeProvider>
     );
@@ -112,7 +118,7 @@ Object.entries(allComponents).forEach(([name, Component]) => {
     it('should render', () => {
       const testId = `component-${name}`;
       const { getByTestId } = render(
-        <ThemeProvider>
+        <ThemeProvider theme={themeWithIcons}>
           <Component data-testid={testId} />
         </ThemeProvider>
       );
@@ -122,7 +128,7 @@ Object.entries(allComponents).forEach(([name, Component]) => {
     it('should pass basic style props', () => {
       const color = '#e3e3e3';
       const { getByTestId } = render(
-        <ThemeProvider>
+        <ThemeProvider theme={themeWithIcons}>
           <Component data-testid={name} color={color} />
         </ThemeProvider>
       );
@@ -145,7 +151,7 @@ Object.entries(allComponents).forEach(([name, Component]) => {
         }, [ref]);
 
         return (
-          <ThemeProvider>
+          <ThemeProvider theme={themeWithIcons}>
             <Component ref={ref} id={refId} data-testid={name} />
             <div data-testid="ref-content">{id}</div>
           </ThemeProvider>
@@ -160,7 +166,7 @@ Object.entries(allComponents).forEach(([name, Component]) => {
     it('should pass shorthand props', () => {
       const backgroundColor = '#e3e3e3';
       const { getByTestId } = render(
-        <ThemeProvider>
+        <ThemeProvider theme={themeWithIcons}>
           <Component data-testid={name} bg={backgroundColor} />
         </ThemeProvider>
       );
@@ -194,7 +200,7 @@ Object.entries(allComponents).forEach(([name, Component]) => {
     it('should not forward style props', () => {
       const width = '50px';
       const { getByTestId } = render(
-        <ThemeProvider>
+        <ThemeProvider theme={themeWithIcons}>
           <Component data-testid={name} width={width} />
         </ThemeProvider>
       );
@@ -211,7 +217,7 @@ describe(`<Icon />`, () => {
   it('should render', () => {
     const testId = `component-icon`;
     const { getByTestId } = render(
-      <ThemeProvider>
+      <ThemeProvider theme={themeWithIcons}>
         <Icon name="plus" data-testid={testId} />
       </ThemeProvider>
     );
@@ -221,7 +227,7 @@ describe(`<Icon />`, () => {
   it('should pass basic style props', () => {
     const color = '#e3e3e3';
     const { getByTestId } = render(
-      <ThemeProvider>
+      <ThemeProvider theme={themeWithIcons}>
         <Icon name="plus" data-testid="icon" size="36px" color={color} />
       </ThemeProvider>
     );
@@ -237,7 +243,7 @@ describe(`<Icon />`, () => {
     const iconName = 'invalid-icon-name';
 
     const { queryByTestId } = render(
-      <ThemeProvider>
+      <ThemeProvider theme={themeWithIcons}>
         <Icon name="invalid-icon-name" data-testid="icon" />
       </ThemeProvider>
     );
@@ -251,7 +257,7 @@ describe(`<Icon />`, () => {
   it('should pass shorthand props', () => {
     const backgroundColor = '#e3e3e3';
     const { getByTestId } = render(
-      <ThemeProvider>
+      <ThemeProvider theme={themeWithIcons}>
         <Icon name="plus" data-testid="icon" bg={backgroundColor} />
       </ThemeProvider>
     );
@@ -304,7 +310,11 @@ Object.entries(THEMEABLE_COMPONENTS).forEach(([name, Component]: any[]) => {
 
     it('should still render when theme has no custom styles', () => {
       const { getByTestId } = render(
-        <ThemeProvider theme={{}}>
+        <ThemeProvider
+          theme={{
+            icons: defaultIcons,
+          }}
+        >
           <Component data-testid={name} />
         </ThemeProvider>
       );


### PR DESCRIPTION
BREAKING CHANGE:
Icons must now be manually imported and included in ThemeProvider

This might be a huge mistake.