### PR TITLE
fix: make the checkbox keyboard accessible

### DIFF
--- a/src/Checkbox/index.tsx
+++ b/src/Checkbox/index.tsx
@@ -80,11 +80,12 @@ export const Checkbox = forwardRef(function Checkbox(
 
   // Allow checkbox to be keyboard accessible
   const handleKeyDown: CheckboxProps['onKeyDown'] = e => {
-    if (e.key === ' ') {
+    if (e.key === ' ' && !onKeyDown) {
       e.preventDefault();
       onChange?.();
-      onKeyDown?.(e);
     }
+
+    onKeyDown?.(e);
   };
 
   return (

--- a/src/Checkbox/index.tsx
+++ b/src/Checkbox/index.tsx
@@ -76,7 +76,16 @@ export const Checkbox = forwardRef(function Checkbox(
   props: CheckboxProps,
   ref: any
 ) {
-  const { children, checked = false, onChange, ...rest } = props;
+  const { children, checked = false, onChange, onKeyDown, ...rest } = props;
+
+  // Allow checkbox to be keyboard accessible
+  const handleKeyDown: CheckboxProps['onKeyDown'] = e => {
+    if (e.key === ' ') {
+      e.preventDefault();
+      onChange?.();
+      onKeyDown?.(e);
+    }
+  };
 
   return (
     <CheckboxContainer as="label" ref={ref} {...rest}>
@@ -84,6 +93,7 @@ export const Checkbox = forwardRef(function Checkbox(
         data-testid="checkbox-container"
         checked={checked}
         onChange={onChange}
+        onKeyDown={handleKeyDown}
       >
         <VisuallyHidden as={CustomCheckboxInput} />
         <ControlBox data-testid="control-box" tabIndex={0} checked={checked}>

--- a/test/checkbox.test.tsx
+++ b/test/checkbox.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import 'jest-styled-components';
 import * as ReactDOM from 'react-dom';
 import { Checkbox, ThemeProvider } from '../src';
@@ -69,4 +69,20 @@ describe('Checkbox', () => {
 
   //   expect(getByTestId('control-box')).toHaveStyleRule('background-color', '#5850ec');
   // });
+
+  it('is accessible via the keyboard', () => {
+    const labelText = 'Checked Checkbox';
+    const handleChange = jest.fn();
+
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <Checkbox onChange={handleChange}>{labelText}</Checkbox>
+      </ThemeProvider>
+    );
+    const checkbox = getByTestId('control-box');
+
+    fireEvent.keyDown(checkbox, { key: ' ' });
+
+    expect(handleChange).toHaveBeenCalled();
+  });
 });

--- a/test/checkbox.test.tsx
+++ b/test/checkbox.test.tsx
@@ -85,4 +85,22 @@ describe('Checkbox', () => {
 
     expect(handleChange).toHaveBeenCalled();
   });
+
+  it('can trigger onKeyDown if provided', () => {
+    const labelText = 'Checked Checkbox';
+    const handleChange = jest.fn();
+    const handleKeyDown = jest.fn();
+
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <Checkbox onChange={handleChange} onKeyDown={handleKeyDown}>{labelText}</Checkbox>
+      </ThemeProvider>
+    );
+    const checkbox = getByTestId('control-box');
+
+    fireEvent.keyDown(checkbox, { key: ' ' });
+
+    expect(handleChange).not.toHaveBeenCalled();
+    expect(handleKeyDown).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## The Issue

The checkbox component is not keyboard accessible.

## The Solution

Add a `handleKeyDown` to be passed to the checkbox by default to ensure the user can change the value of the checkbox with the spacebar.

## To Test

- Run `storybook`
- Navigate to the [checkbox page](http://localhost:6006/?path=/docs/elements-checkbox--page)
- Focus the checkbox via the keyboard
- Use the spacebar to check and uncheck the checkbox
- Run `yarn test checkbox` to ensure the new test passes

## Visuals

### Before

Checkbox would not change and the page would scroll to the bottom

![checkbox_before_demo](https://user-images.githubusercontent.com/20483201/96073736-a86e7480-0e6c-11eb-979b-f7d7e24b3e22.gif)

### After

Checkbox value changes successfully and the page does not scroll

![checkbox_after_demo](https://user-images.githubusercontent.com/20483201/96073748-b0c6af80-0e6c-11eb-8503-40b70d743087.gif)
